### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/scripts/check-bible-access.ts
+++ b/scripts/check-bible-access.ts
@@ -35,8 +35,7 @@ async function checkBibleAccess() {
     process.exit(1)
   }
 
-  console.log('🔍 Checking Bible access for your API key...\n')
-  console.log(`API Key (first 10 chars): ${BIBLE_API_KEY.substring(0, 10)}...\n`)
+  console.log('🔍 Checking Bible access using the configured API key...\n')
 
   try {
     const response = await fetch('https://rest.api.bible/v1/bibles', {


### PR DESCRIPTION
Potential fix for [https://github.com/vcjr/christians-innovate-app/security/code-scanning/1](https://github.com/vcjr/christians-innovate-app/security/code-scanning/1)

In general, to fix clear-text logging of sensitive information, remove the sensitive data from log messages or replace it with non-sensitive metadata (e.g., “API key is set” or a fully redacted/masked token that cannot realistically be abused). Logging whether a key is present, or that a request is being made, is usually sufficient.

For this specific script, the problematic line is 39, which logs the first 10 characters of `BIBLE_API_KEY`. The safest fix that preserves existing behavior (checking access and informing the user) is to stop logging any part of the key. Instead, log a generic message such as “Using configured API key to query accessible Bibles…”. This keeps the user informed that the script is using an API key without exposing any portion of it. No additional functions or imports are required; we only need to change the log message on line 39 in `scripts/check-bible-access.ts`. The rest of the script can remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
